### PR TITLE
Use default Maven repo name.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,8 +13,6 @@ GRPC_KOTLIN_VERSION = "1.4.1"
 
 PROTOBUF_JAVA_VERSION = "3.21.12"  # Compatible with protobuf version.
 
-MAVEN_REPO_NAME = "rules_kotlin_jvm_maven"
-
 bazel_dep(
     name = "bazel_skylib",
     version = "1.5.0",
@@ -43,14 +41,12 @@ bazel_dep(
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.artifact(
-    name = MAVEN_REPO_NAME,
     artifact = "protoc-gen-grpc-kotlin",
     classifier = "jdk8",
     group = "io.grpc",
     version = GRPC_KOTLIN_VERSION,
 )
 maven.install(
-    name = MAVEN_REPO_NAME,
     artifacts = [
         "org.jetbrains.kotlin:kotlin-stdlib:" + KOTLIN_RELEASE_VERSION,
         "org.jetbrains.kotlin:kotlin-stdlib-common:" + KOTLIN_RELEASE_VERSION,
@@ -66,10 +62,10 @@ maven.install(
         "com.google.protobuf:protobuf-kotlin:" + PROTOBUF_JAVA_VERSION,
         "com.google.guava:guava:33.0.0-jre",
     ],
-    fetch_sources = True,
+    fetch_sources = True,  # For IDE integration.
     strict_visibility = True,
 )
-use_repo(maven, MAVEN_REPO_NAME)
+use_repo(maven, "maven")
 
 non_module_deps = use_extension("//:non_module_deps.bzl", "non_module_deps")
 non_module_deps.grpc_java_plugin_version(

--- a/imports/com/google/common/BUILD.bazel
+++ b/imports/com/google/common/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "guava",
-    actual = "@rules_kotlin_jvm_maven//:com_google_guava_guava",
+    actual = "@maven//:com_google_guava_guava",
 )

--- a/imports/com/google/protobuf/BUILD.bazel
+++ b/imports/com/google/protobuf/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "protobuf",
-    actual = "@rules_kotlin_jvm_maven//:com_google_protobuf_protobuf_java",
+    actual = "@maven//:com_google_protobuf_protobuf_java",
 )

--- a/imports/com/google/protobuf/kotlin/BUILD.bazel
+++ b/imports/com/google/protobuf/kotlin/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "kotlin",
-    actual = "@rules_kotlin_jvm_maven//:com_google_protobuf_protobuf_kotlin",
+    actual = "@maven//:com_google_protobuf_protobuf_kotlin",
 )

--- a/imports/io/gprc/BUILD.bazel
+++ b/imports/io/gprc/BUILD.bazel
@@ -2,10 +2,10 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "api",
-    actual = "@rules_kotlin_jvm_maven//:io_grpc_grpc_api",
+    actual = "@maven//:io_grpc_grpc_api",
 )
 
 alias(
     name = "protoc_gen_grpc_kotlin_jdk8",
-    actual = "@rules_kotlin_jvm_maven//:io_grpc_protoc_gen_grpc_kotlin_jdk8",
+    actual = "@maven//:io_grpc_protoc_gen_grpc_kotlin_jdk8",
 )

--- a/imports/io/gprc/kotlin/BUILD.bazel
+++ b/imports/io/gprc/kotlin/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "stub",
-    actual = "@rules_kotlin_jvm_maven//:io_grpc_grpc_kotlin_stub",
+    actual = "@maven//:io_grpc_grpc_kotlin_stub",
 )

--- a/imports/io/gprc/protobuf/BUILD.bazel
+++ b/imports/io/gprc/protobuf/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "protobuf",
-    actual = "@rules_kotlin_jvm_maven//:io_grpc_grpc_protobuf",
+    actual = "@maven//:io_grpc_grpc_protobuf",
 )

--- a/imports/io/gprc/stub/BUILD.bazel
+++ b/imports/io/gprc/stub/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "stub",
-    actual = "@rules_kotlin_jvm_maven//:io_grpc_grpc_stub",
+    actual = "@maven//:io_grpc_grpc_stub",
 )

--- a/imports/kotlin/BUILD.bazel
+++ b/imports/kotlin/BUILD.bazel
@@ -3,7 +3,7 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "stdlib",
     exports = [
-        "@rules_kotlin_jvm_maven//:org_jetbrains_kotlin_kotlin_stdlib",
-        "@rules_kotlin_jvm_maven//:org_jetbrains_kotlin_kotlin_stdlib_common",
+        "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
+        "@maven//:org_jetbrains_kotlin_kotlin_stdlib_common",
     ],
 )

--- a/imports/kotlin/reflect/BUILD.bazel
+++ b/imports/kotlin/reflect/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "reflect",
-    actual = "@rules_kotlin_jvm_maven//:org_jetbrains_kotlin_kotlin_reflect",
+    actual = "@maven//:org_jetbrains_kotlin_kotlin_reflect",
 )

--- a/imports/kotlin/test/BUILD.bazel
+++ b/imports/kotlin/test/BUILD.bazel
@@ -2,5 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "test",
-    actual = "@rules_kotlin_jvm_maven//:org_jetbrains_kotlin_kotlin_test",
+    actual = "@maven//:org_jetbrains_kotlin_kotlin_test",
 )

--- a/imports/kotlinx/coroutines/BUILD.bazel
+++ b/imports/kotlinx/coroutines/BUILD.bazel
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "core",
     exports = [
-        "@rules_kotlin_jvm_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
-        "@rules_kotlin_jvm_maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
     ],
 )


### PR DESCRIPTION
This ensures a single version for library dependencies that come from Maven.

See https://github.com/bazelbuild/rules_jvm_external/issues/1035#issuecomment-1894443436 and bazelbuild/rules_jvm_external#995.